### PR TITLE
added database build and load step

### DIFF
--- a/01-select.html
+++ b/01-select.html
@@ -28,7 +28,7 @@
           <h1 class="title">Databases and SQL</h1>
           <h2 class="subtitle">Selecting Data</h2>
 <div id="learning-objectives" class="objectives">
-<h2 id="learning-objectives" class="objectives">Learning Objectives</h2>
+<h2>Learning Objectives</h2>
 <ul>
 <li>Explain the difference between a table, a record, and a field.</li>
 <li>Explain the difference between a database and a database manager.</li>
@@ -305,7 +305,11 @@
 </tbody>
 </table>
 </blockquote>
-<p>Notice that three entries --- one in the <code>Visited</code> table, and two in the <code>Survey</code> table --- don't contain any actual data, but instead have a special <code>-null-</code> entry: we'll return to these missing values <a href="05-null.html">later</a>. For now, let's write an SQL query that displays scientists' names. We do this using the SQL command <code>select</code>, giving it the names of the columns we want and the table we want them from. Our query and its output look like this:</p>
+<p>Notice that three entries --- one in the <code>Visited</code> table, and two in the <code>Survey</code> table --- don't contain any actual data, but instead have a special <code>-null-</code> entry: we'll return to these missing values <a href="05-null.html">later</a>. For now, we can create this example database with the command</p>
+<pre class="sourceCode sql"><code class="sourceCode sql">sqlite3 survey.db &lt; gen-survey-database.sql</code></pre>
+<p>and load it into our database manager via</p>
+<pre class="sourceCode sql"><code class="sourceCode sql">sqlite3 survey.db</code></pre>
+<p>Now let's write an SQL query that displays scientists' names. We do this using the SQL command <code>select</code>, giving it the names of the columns we want and the table we want them from. Our query and its output look like this:</p>
 <pre class="sourceCode sql"><code class="sourceCode sql"><span class="kw">select</span> family, personal <span class="kw">from</span> Person;</code></pre>
 <table>
 <thead>

--- a/01-select.md
+++ b/01-select.md
@@ -15,7 +15,7 @@ is a way to store and manipulate information
 that is arranged as **tables**.
 Each table has columns (also known as **fields**) which describe the data,
 and rows (also known as **records**) which contain the data.
-  
+
 When we are using a spreadsheet,
 we put formulas into cells to calculate new values based on old ones.
 When we are using a database,
@@ -26,7 +26,7 @@ a program that manipulates the database for us.
 The database manager does whatever lookups and calculations the query specifies,
 returning the results in a tabular form
 that we can then use as a starting point for further queries.
-  
+
 > Every database manager --- Oracle,
 > IBM DB2, PostgreSQL, MySQL, Microsoft Access, and SQLite --- stores
 > data in a different way,
@@ -44,17 +44,17 @@ but that handful accounts for most of what scientists do.
 The tables below show the database we will use in our examples:
 
 > **Person**: people who took readings.
-> 
-> |ident   |personal |family    
+>
+> |ident   |personal |family
 > |--------|---------|----------
-> |dyer    |William  |Dyer      
-> |pb      |Frank    |Pabodie   
-> |lake    |Anderson |Lake      
-> |roe     |Valentina|Roerich   
+> |dyer    |William  |Dyer
+> |pb      |Frank    |Pabodie
+> |lake    |Anderson |Lake
+> |roe     |Valentina|Roerich
 > |danforth|Frank    |Danforth  
 
 > **Site**: locations where readings were taken.
-> 
+>
 > |name |lat   |long   |
 > |-----|------|-------|
 > |DR-1 |-49.85|-128.57|
@@ -62,7 +62,7 @@ The tables below show the database we will use in our examples:
 > |MSK-4|-48.87|-123.4 |
 
 > **Visited**: when readings were taken at specific sites.
-> 
+>
 > |ident|site |dated     |
 > |-----|-----|----------|
 > |619  |DR-1 |1927-02-08|
@@ -75,7 +75,7 @@ The tables below show the database we will use in our examples:
 > |844  |DR-1 |1932-03-22|
 
 > **Survey**: the actual readings.
-> 
+>
 > |taken|person|quant|reading|
 > |-----|------|-----|-------|
 > |619  |dyer  |rad  |9.82   |
@@ -105,7 +105,19 @@ and two in the `Survey` table --- don't contain any actual
 data, but instead have a special `-null-` entry:
 we'll return to these missing values [later](05-null.html).
 For now,
-let's write an SQL query that displays scientists' names.
+we can create this example database with the command
+
+~~~ {.sql}
+sqlite3 survey.db < gen-survey-database.sql
+~~~
+
+and load it into our database manager via
+
+~~~ {.sql}
+sqlite3 survey.db
+~~~
+
+Now let's write an SQL query that displays scientists' names.
 We do this using the SQL command `select`,
 giving it the names of the columns we want and the table we want them from.
 Our query and its output look like this:


### PR DESCRIPTION
`01-select.md` jumps right into queries without telling anyone how to load or build the database; as a result, I've seen instructors stumble over this step, and I took about the most circuitous route possible to rebuild `survey.db` in #11 and #12 - @acabunoc suggested a better solution, the syntax of which I have included at the start of the lesson, so everyone loads and builds their database the same way.