### PR TITLE
Update swc.css

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -272,6 +272,11 @@ section.content {
     background:#2b3990;
 }
 
+/* In tables the default font color and the header color are very close */
+tr.header {
+    background: #e0ffff;
+}
+
 .header h1 {
     line-height: 1.1;
     margin: 60px 0px 80px;


### PR DESCRIPTION
In the html view of the lessons, the table headers are very difficult to read because the default header color of dark blue is very close to the default font color. I've simply added a rule that lightens the blue when the header style appears inside a table row. I'm not sure if this is the best way to fix the problem - so I won't be offended if this change is rejected :)