### PR TITLE
Update 01-select.md

### DIFF
--- a/01-select.md
+++ b/01-select.md
@@ -142,6 +142,7 @@ SeLeCt FaMiLy, PeRsOnAl FrOm PeRsOn;
 |Roerich |Valentina|
 |Danforth|Frank    |
 
+You can use SQL's case insensitivity to your advantage. For instance, some people choose to write SQL keywords (such as `SELECT` and `FROM`) in capital letters and **field** and **table** names in lower case. This can make it easier to locate parts of an SQL statement. For insance, you can scan the statement, quickly locate the prominent `FROM` keyword and know the table name follows.
 Whatever casing convention you choose,
 please be consistent:
 complex queries are hard enough to read without the extra cognitive load of random capitalization.


### PR DESCRIPTION
I propose this change partly to introduce the notion of SQL keywords as distinct from field or table names, and partly to motivate the idea of sticking to a convention for capitalisation of statements.

Otherwise, my worry is that a person will get to the final challenge and not really understand why some parts of the two statements given are capitalised. Both examples are consistent in their own way. e.g. the first capitalises keywords. And the latter capitalises table names and proper cases field names. But to someone with no prior SQL experience, these patterns may not be immediately apparent, precisely because they may not intuit that SQL is composed of keywords and references to fields and tables.

Final thought - neither of the conventions in the challenge are adopted in the SQL statements in the lesson. The example SQL statements are entirely in lowercase (but with nice syntax highlighting). I'm not sure what the prevailing view is, but for me using capitalisation to distinguish between parts of SQL is a good practice. If others agree, then perhaps the example SQL statements should adopt one of these conventions, so as to encourage this good practice?