### PR TITLE
03-filter.md: Drop redundant parentheses

### DIFF
--- a/03-filter.md
+++ b/03-filter.md
@@ -56,16 +56,13 @@ For example,
 we can ask for all information from the DR-1 site collected since 1930:
 
 ~~~ {.sql}
-SELECT * FROM Visited WHERE (site="DR-1") AND (dated<="1930-00-00");
+SELECT * FROM Visited WHERE site="DR-1" AND dated<="1930-00-00";
 ~~~
 
 |ident|site|dated     |
 |-----|----|----------|
 |619  |DR-1|1927-02-08|
 |622  |DR-1|1927-02-10|
-
-(The parentheses around the individual tests aren't strictly required,
-but they help make the query easier to read.)
 
 > Most database managers have a special data type for dates.
 > In fact, many have two:


### PR DESCRIPTION
We've had these since 61ae6ffb (First three lessons on SQL for
beginners, 2013-11-09).  Maybe these helped a bit before the keyword
capitalization from b248d96 (Merge pull request #38 from
timtomch/gh-pages, 2015-02-23), but now I think they just clutter the
query.  If folks felt that parenthesis were a key to readability, we'd
all be writing Lisp, and nobody would bother with operator precedence
;).