### PR TITLE
Cleanup merge conflict resolution from #47, #48, #49, and #50

### DIFF
--- a/03-filter.md
+++ b/03-filter.md
@@ -56,7 +56,7 @@ For example,
 we can ask for all information from the DR-1 site collected before 1930:
 
 ~~~ {.sql}
-SELECT * FROM Visited WHERE site='DR-1' AND dated<'1930-00-00';
+SELECT * FROM Visited WHERE site='DR-1' AND dated<'1930-01-01';
 ~~~
 
 |ident|site|dated     |

--- a/03-filter.md
+++ b/03-filter.md
@@ -56,7 +56,7 @@ For example,
 we can ask for all information from the DR-1 site collected before 1930:
 
 ~~~ {.sql}
-SELECT * FROM Visited WHERE site="DR-1" AND dated<="1930-00-00";
+SELECT * FROM Visited WHERE site='DR-1' AND dated<'1930-00-00';
 ~~~
 
 |ident|site|dated     |

--- a/03-filter.md
+++ b/03-filter.md
@@ -64,14 +64,8 @@ SELECT * FROM Visited WHERE site='DR-1' AND dated<'1930-00-00';
 |619  |DR-1|1927-02-08|
 |622  |DR-1|1927-02-10|
 
-<<<<<<< HEAD
-(The parentheses around the individual tests aren't strictly required,
-but they help make the query easier to read.)
-
 > ## Date types {.callout}
 >
-=======
->>>>>>> 06563c2f46681b04db26066a231d9dc237c0ffa0
 > Most database managers have a special data type for dates.
 > In fact, many have two:
 > one for dates,

--- a/05-null.md
+++ b/05-null.md
@@ -42,7 +42,7 @@ Null doesn't behave like other values.
 If we select the records that come before 1930:
 
 ~~~ {.sql}
-SELECT * FROM Visited WHERE dated<"1930-01-01";
+SELECT * FROM Visited WHERE dated<'1930-01-01';
 ~~~
 
 |ident|site|dated     |
@@ -54,7 +54,7 @@ we get two results,
 and if we select the ones that come during or after 1930:
 
 ~~~ {.sql}
-SELECT * FROM Visited WHERE dated>="1930-01-01";
+SELECT * FROM Visited WHERE dated>='1930-01-01';
 ~~~
 
 |ident|site|dated     |


### PR DESCRIPTION
Several of these PRs made semantically independent changes to the same
set of lines, which lead to a number of merge conflicts.  While most
of the merge conflicts were resolved appropriately, some of the
resolutions accidentally reverted one of the semantic changes.  This
PR goes through and corrects those mistakes, so we get all the changes
intended by the various PRs.  Details about an individual fix, the
change being restored, and the merge that I'm fixing are in the
individual commit messages.