### PR TITLE
07-join.md: Link to SQLite's rowid docs

### DIFF
--- a/07-join.md
+++ b/07-join.md
@@ -201,7 +201,7 @@ those IDs have names like "student numbers" and "patient numbers",
 and they almost always turn out to have originally been
 a unique record identifier in some database system or other.
 As the query below demonstrates,
-SQLite automatically numbers records as they're added to tables,
+SQLite [automatically numbers records][rowid] as they're added to tables,
 and we can use those record numbers in queries:
 
 ~~~ {.sql}
@@ -239,3 +239,4 @@ SELECT rowid, * FROM Person;
 > and the type of measurement taken and its reading. Please avoid all null values.
 > Tip: you should get 15 records with 8 fields.
 
+[rowid]: https://www.sqlite.org/lang_createtable.html#rowid


### PR DESCRIPTION
The automatic numbering is optional, and you can opt-out by creating a
[WITHOUT ROWID table][1].  Personally, I'd suggest an
explicitly-declared INTEGER PRIMARY KEY column to avoid relying on
['rowid'][2]:

  With one exception noted below, if a rowid table has a primary key
  that consists of a single column and the declared type of that
  column is "INTEGER" in any mixture of upper and lower case, then the
  column becomes an alias for the rowid. Such a column is usually
  referred to as an "integer primary key".

[1]: https://www.sqlite.org/withoutrowid.html
[2]: https://www.sqlite.org/lang_createtable.html#rowid