### PR TITLE
removing IPython as we do not have "room" to add R

### DIFF
--- a/00-setup.md
+++ b/00-setup.md
@@ -59,28 +59,5 @@ You can change some SQLite settings to make the output easier to read:
     MSK-4       -48.87      -123.4
 
 
-#### IPython notebook
-
-Create a new IPython notebook and run
-
-    import sqlite3
-
-This should complete without an error.
-
-In another cell, run
-
-    %install_ext https://raw.githubusercontent.com/benwaugh/sql-novice-survey/gh-pages/code/sqlitemagic.py
-
-This should give the following output:
-
-    Installed sqlitemagic.py. To use it, type:
-      %load_ext sqlitemagic
-
-Run this command as intructed, and then in a new cell run this:
-
-    %%sqlite survey.db
-    select * from Site
-
-You should see the contents of the <code>Site</code> table.
 
 


### PR DESCRIPTION
in fact, my natural instinct is to _add R and RSQLite_ as per
```{.r}
R> library(RSQLite)
Loading required package: DBI
R> con <- dbConnect(RSQLite::SQLite(), "survey.db")
R> dbListTables(con)
[1] "Person"  "Site"    "Survey"  "Visited"
R> 
```
but then the instruction to not add _new topics_.  If I misunderstood, just make a comment and close and I will submit an addition showing how to set up R (expanding on the three lines above).

otherwise this conforms to the request to provide a PR which _deletes something you think we don’t need_

submitted per request of @gvwilson and as part of wrapping up teaching