### PR TITLE
00-setup.md Minor Tweaks

### DIFF
--- a/00-setup.md
+++ b/00-setup.md
@@ -34,9 +34,11 @@ Type
 
     sqlite3 survey.db
 
-Then type the SQLite command <code>.tables</code> to list the tables in the database, and
-an SQL <code>SELECT</code> command. You should see
-something like the following.
+Then type the SQLite command <code>.tables</code> to list the tables in the database, and this SQL command: 
+
+<code>select * from Site;</code>
+
+Make sure to include the semi-colon **;** at the end of the statement. You should see something like the following.
 
     SQLite version 3.8.8 2015-01-16 12:08:06
     Enter ".help" for usage hints.
@@ -59,28 +61,11 @@ You can change some SQLite settings to make the output easier to read:
     MSK-4       -48.87      -123.4
 
 
-#### IPython notebook
+#### Helpful Commands
 
-Create a new IPython notebook and run
-
-    import sqlite3
-
-This should complete without an error.
-
-In another cell, run
-
-    %install_ext https://raw.githubusercontent.com/benwaugh/sql-novice-survey/gh-pages/code/sqlitemagic.py
-
-This should give the following output:
-
-    Installed sqlitemagic.py. To use it, type:
-      %load_ext sqlitemagic
-
-Run this command as intructed, and then in a new cell run this:
-
-    %%sqlite survey.db
-    select * from Site
-
-You should see the contents of the <code>Site</code> table.
+* For a list of useful system commands, enter <code>.help</code>
+* To exit sqlite and return to the shell command line, you can use either 
+	* <code>.quit</code> *or*
+	* <code>.exit</code>
 
 


### PR DESCRIPTION
- Removing Python setup
- Rewriting test SQL command. The previous text told the novice user 'to type
a SQL select command'. A novice user wouldn't know what that means. Shortly
 after that instruction, the file has a select command hidden away in a big
block of code. A novice user might be intimated by that block of code and
embarrassed by not knowing what to do. This revision clarifies the original
author's instruction while maintaining their good intentions.

- Copied in a very necessary section with helpful commands for SQLite Help and
how to exit the program. As someone who has gotten stuck in Vim more times
than I care to remember, I can assure you that novice learners will be glad to
have these commands. (Greg, this is copied from the instructor's guide, so
it's not exactly new material...)