### PR TITLE
discussion page -> Discussion

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ These lessons will show how to use a database to explore the expeditions' data.
 > learners will need to know how to install browser plugins
 > (and have permission to do so).
 >
-> Check the [discussion page](discussion.html) for database setup instructions
+> Check [Discussion](discussion.html) for database setup instructions
 
 ## Topics
 


### PR DESCRIPTION
* fix error generated by running make check

    ERROR: In ./index.md: The linked page discussion.html exists, but the link text 'discussion page' 
    does not match the (sub)title of that page, 'Discussion'.
    WARNING: Some errors were encountered during validation. See log for details.