### PR TITLE
Added SQL formatting to markdown

### DIFF
--- a/03-filter.md
+++ b/03-filter.md
@@ -229,7 +229,7 @@ not to the entire rows as they are being processed.
 > Suppose we want to select all sites that lie more than 30 degrees from the poles.
 > Our first query is:
 >
-> ~~~
+> ~~~ {.sql}
 > SELECT * FROM Site WHERE (lat > -60) OR (lat < 60);
 > ~~~
 >

--- a/05-null.md
+++ b/05-null.md
@@ -182,7 +182,7 @@ In contrast to arithmetic or Boolean operators, aggregation functions that combi
 >
 > What do you expect the query:
 >
-> ~~~
+> ~~~ {.sql}
 > SELECT * FROM Visited WHERE dated IN ('1927-02-08', NULL);
 > ~~~
 >


### PR DESCRIPTION
Some of the SQL samples weren't labeled leading to a lack of color formatting. All of the SQL samples are properly marked now.