### PR TITLE
Update links to instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,10 @@ You also agree to abide by our
 2.  For our lessons,
     you should branch from and submit pull requests against the `gh-pages` branch.
 
-3.  When editing lesson pages, you need only commit changes to the Markdown source files.
+3.  When editing lessons, please only commit changes to the Markdown
+    files, *not* the generated HTML.  We will re-create the HTML after
+    your pull request is merged.  (Working this way ensures that each
+    change only needs to be reviewed once, in one place.)
 
 4.  If you're looking for things to work on,
     please see [the list of issues for this repository][issues],

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ sql-novice-survey
 
 First encounter with SQL using the Antarctic survey data as an example.
 
-> Please see [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
+> Please see [https://github.com/swcarpentry/lesson-example](https://github.com/swcarpentry/lesson-example)
 > for instructions on formatting, building, and submitting lessons,
 > or run `make` in this directory for a list of helpful commands.


### PR DESCRIPTION
Pointing at lesson-example instead of lesson-template, and telling people (again) not to commit HTML.