### PR TITLE
Troubleshooting sqlite3: readline wrapper for command history

### DIFF
--- a/instructors.md
+++ b/instructors.md
@@ -101,6 +101,7 @@ to make it easier for scientists to find what they want to.
 
 *   @tomwright01: 3 hours
 *   @mckays630: 3 hrs (up to Aggregation, using only shell interface)
+*   @benwaugh: 3 hours (rather rushed, touching only briefly on aggregation in order to leave 30 minutes for combining data)
 
 ## Resources
 

--- a/instructors.md
+++ b/instructors.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Lesson Title
+title: Databases and SQL
 subtitle: Instructor's Guide
 ---
 > ### database (dā'tə-bās') noun {.callout}

--- a/instructors.md
+++ b/instructors.md
@@ -215,3 +215,25 @@ $
 ~~~
 
 Note: There also instructions targeted at participants in the general [discussion page](discussion.html)
+
+## Troubleshooting
+
+The command history and line editing features provided by `readline` are
+invaluable with a command-line tool like `sqlite3`. Participants should be
+encouraged strongly to start with a simple SQL statement and then use the
+up-arrow key to go back and add clauses one at a time, or fix problems, rather
+than typing each command from scratch. Unfortunately on some Linux and Mac OSX
+systems participants have found that the arrow keys do not scroll through the
+command history as expected.
+
+A workaround for this it to use the [rlwrap](https://github.com/hanslub42/rlwrap)
+(readline wrapper) command when starting SQLite:
+
+~~~ {.bash}
+$ rlwrap sqlite3 survey.db
+~~~
+
+Availability: the `rlwrap` package is available in the standard Fedora
+repository (but wasn't needed when I [@benwaugh] taught this) and appears
+to be available in [Ubuntu](http://packages.ubuntu.com/precise/rlwrap) too,
+and in [OSX using Homebrew](https://news.ycombinator.com/item?id=5087790).


### PR DESCRIPTION
A participant at UCL discovered the `rlwrap` command, which works round the problem that affected a few OSX and Linux users who weren't able to scroll back and amend earlier commands.

Also added timing information from UCL workshop, and fixed title on instructor's guide for SQL lesson.