### PR TITLE
Query definition

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -117,7 +117,7 @@ primary key
 :   One or more [fields](#field) in a [database table](#table) whose values are guaranteed to be unique for each [record](#record), i.e., whose values uniquely identify the entry.
 
 query
-:   A database operation that reads values but does not modify anything. Queries are expressed in a special-purpose language called [SQL](#sql).
+:   A database operation that reads values but does not modify anything. Queries are expressed in a special-purpose language called [SQL](#sql). 
 
 record
 :   A set of related values making up a single entry in a [database table](#table), typically shown as a row. See also: [field](#field).


### PR DESCRIPTION
The query definition is not consistent with what is said on the creating and modifying data
Records can be inserted, updated, or deleted using "queries".
Whereas query definition says: A database operation that reads values but does not modify anything. 

I think queries not only retrieve information, but Insert, Update, Drop statements can also be called queries? 
Either one of those two should be fixed.