### PR TITLE
suggestion to add providing an alias for queries in calc

### DIFF
--- a/04-calc.md
+++ b/04-calc.md
@@ -51,6 +51,19 @@ SELECT taken, round(5*(reading-32)/9, 2) FROM Survey WHERE quant='temp';
 |751  |-28.06                     |
 |752  |-26.67                     |
 
+As you can see from this example, though, the string describing our new field (generated from the equation) can become quite unwieldy. SQL allows us to rename our fields, any field for that matter, whether it was calculated or one of the existing fields in our database, for succinctness and clarity. For example, we could write the previous query as: 
+
+~~~ {.sql}
+SELECT taken, round(5*(reading-32)/9, 2) as Celsius FROM Survey WHERE quant='temp';
+~~~
+
+|taken|Celsius|
+|-----|-------|
+|734  |-29.72 |
+|735  |-32.22 |
+|751  |-28.06 |
+|752  |-26.67 |
+
 We can also combine values from different fields,
 for example by using the string concatenation operator `||`:
 


### PR DESCRIPTION
A suggestion to add an example of providing an alias to the name of a field in an SQL query. I think this will demonstrate that simple formatting can be done easily within SQL to facilitate intuitive output. This would fit particularly well in the 'calc' lesson given the obtuse field name stemming from the equation to convert F to C.