### PR TITLE
Fix markdown formatting in 09-create

### DIFF
--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -52,12 +52,12 @@ but it's better not to have to rely on it.
 Different database systems support different data types for table columns,
 but most provide the following:
 
-data type  use
----------  -----------------------------------------
-INTEGER    a signed integer
-REAL       a floating point number
-TEXT       a character string
-BLOB       a "binary large object", such as an image
+|data type|  use                                       | 
+|---------|  ----------------------------------------- |
+|INTEGER  |  a signed integer                          |
+|REAL     |  a floating point number                   |
+|TEXT     |  a character string                        |
+|BLOB     |  a "binary large object", such as an image |
 
 Most databases also support Booleans and date/time values;
 SQLite uses the integers 0 and 1 for the former,


### PR DESCRIPTION
Formatting of SQL datatypes listing was broken.
Switched to markdown table representation.

Before:
![image](https://cloud.githubusercontent.com/assets/552230/25166028/83ce49e8-2496-11e7-9767-85c23ba37d12.png)

After (on Github, not GitHub-Pages):
![image](https://cloud.githubusercontent.com/assets/552230/25166079/c5625a84-2496-11e7-8670-593ef30964f8.png)
