### PR TITLE
Clarified ORDER BY

### DIFF
--- a/_episodes/02-sort-dup.md
+++ b/_episodes/02-sort-dup.md
@@ -137,7 +137,10 @@ from least to greatest).
 
 We can sort in the opposite order using `DESC` (for "descending"):
 
-While it may look that the records are consistent every time we ask for them in this lesson, that is because no one has changed or modified any of the data so far. Remember to use ORDER BY if you want the rows returned to have any sort of consistent or predictable order.
+> ## A note on ordering
+>
+> While it may look that the records are consistent every time we ask for them in this lesson, that is because no one has changed or modified any of the data so far. Remember to use ORDER BY if you want the rows returned to have any sort of consistent or predictable order.
+{: .callout}
 ~~~
 SELECT * FROM person ORDER BY id DESC;
 ~~~

--- a/_episodes/02-sort-dup.md
+++ b/_episodes/02-sort-dup.md
@@ -130,12 +130,14 @@ SELECT * FROM Person ORDER BY id;
 |pb     |Frank    |Pabodie |
 |roe    |Valentina|Roerich |
 
-By default,
-results are sorted in ascending order
+By default, when we use ORDER BY
+results are sorted in ascending order of the column we specify
 (i.e.,
 from least to greatest).
+
 We can sort in the opposite order using `DESC` (for "descending"):
 
+While it may look that the records are consistent every time we ask for them in this lesson, that is because no one has changed or modified any of the data so far. Remember to use ORDER BY if you want the rows returned to have any sort of consistent or predictable order.
 ~~~
 SELECT * FROM person ORDER BY id DESC;
 ~~~


### PR DESCRIPTION
While prepping for the teaching lesson tomorrow, I saw:

"By default, when we use ORDER BY
results are sorted in ascending order " Which is a very worrying statement. While we know that that "default" refers to the ORDER BY clause, I suspect that this will trip up new readers by contradicting the paragraph above of "nothing's returned in any particular order." I added a bit of clarification and an extra warning paragraph. That paragraph might be put into some sort of aside-box, but I'm not sure which one to use.