### PR TITLE
guide: Fix command to create database (needs escaping)

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -89,7 +89,7 @@ Next,
 create the database that will be used:
 
 ~~~
-$ sqlite3 survey.sqlite .read bin/create-db.sql
+$ sqlite3 survey.sqlite '.read bin/create-db.sql'
 ~~~
 {: .bash}
 


### PR DESCRIPTION
See https://github.com/swcarpentry/sql-novice-survey/issues/144#issuecomment-339436541

```console
$ sqlite3 survey.sqlite .read bin/create-db.sql
Usage: .read FILE
(fails)

$ sqlite3 survey.sqlite '.read bin/create-db.sql'
(works)
```