### PR TITLE
Use single quotes for string literals

### DIFF
--- a/_episodes/07-join.md
+++ b/_episodes/07-join.md
@@ -240,8 +240,8 @@ SELECT rowid, * FROM Person;
  > > FROM Site JOIN Visited JOIN Survey 
  > > ON Site.name = Visited.site
  > > AND Visited.id = Survey.taken
- > > WHERE Site.name = "DR-1" 
- > > AND Survey.quant = "rad";
+ > > WHERE Site.name = 'DR-1' 
+ > > AND Survey.quant = 'rad';
  > > ~~~
  > > {: .sql}
  > >
@@ -264,7 +264,7 @@ SELECT rowid, * FROM Person;
  > > ON Site.name = Visited.site
  > > AND Visited.id = Survey.taken
  > > AND Survey.person = Person.id
- > > WHERE Person.personal = "Frank";
+ > > WHERE Person.personal = 'Frank';
  > > ~~~
  > > {: .sql}
  > >

--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -183,7 +183,7 @@ this technique is outside the scope of this chapter.
 >
 > > ## Solution
 > > ~~~
-> > UPDATE Survey SET person = "unknown" WHERE person IS NULL;
+> > UPDATE Survey SET person = 'unknown' WHERE person IS NULL;
 > > ~~~
 > > {: .sql}
 > {: .solution}


### PR DESCRIPTION
Made a PR replacing double quotes with single quotes.
Looks like most of the SQL queries in this lesson use singe quotes. The SQLite FAQ also recommends single quote.

> Use single-quotes, not double-quotes, around string literals in SQL. This is what the SQL standard requires.

Source:  https://www.sqlite.org/faq.html

See also issue #184 