### PR TITLE
Update setup to make clear of some issues faced when installing

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -10,5 +10,17 @@ If you are running Linux, you may already have SQLite3 installed, please use the
 `which sqlite3` to see the path of the program, otherwise you should be able to get it 
 from your package manager (on Debian/Ubuntu, you can use the command `apt install sqlite3`).
 
+If you are running Windows, run installers as administrator.
+Additionally, make sure you select the right installer version for your system.
+We recommend that you use [git for Windows](https://gitforwindows.org/).
+This is described in the [UNIX Shell lesson](http://swcarpentry.github.io/shell-novice/setup.html).
+If the installer asks to add the path to the environment variables, check yes, otherwise you have to manually add the path of the executable to the `PATH` environmental variables.
+This path informs the system where to find the executable program.
+
+If installing SQLite3 using Anaconda, refer to the [anaconda sqlite docs](https://anaconda.org/anaconda/sqlite).
+
+After the installation and the setting of the paths, close the terminal and reopen a new terminal.
+This enables paths and configurations to be loaded.
+
 # Files
 Please download the database we'll be using: [survey.db]({{ page.root }}/files/survey.db)


### PR DESCRIPTION
Some of the issues are outdated and others are solves by either new software releases or running the software as administrator.  The windows-installer is no longer used and we are pointing to 
https://www.sqlite.org/download.html in the current workshop template.
Setup unclear for windows users #269
SQLite installation issue on Windows #118
Installation issues #177
no sqlite prompt #124