### PR TITLE
Fix potentially confusing inconsistency in filtering challenge and solution

### DIFF
--- a/_episodes/03-filter.md
+++ b/_episodes/03-filter.md
@@ -240,7 +240,7 @@ not to the entire rows as they are being processed.
 
 > ## Fix This Query
 >
-> Suppose we want to select all sites that lie more than 42 degrees from the poles.
+> Suppose we want to select all sites that lie more than 48 degrees from the poles.
 > Our first query is:
 >
 > ~~~


### PR DESCRIPTION

The question asks the student to correct the following query such that it "selects all sites that lie more than 42 degrees from the poles":
`SELECT * FROM Site WHERE (lat > -48) OR (lat < 48);`

The answer given changes the logic but leaves the queried value as 48. This seems like the right way to emphasise the error in query logic. I've edited the question to ask about 48 rather than 42 so this is clear.