### PR TITLE
Simplification + solution for group concatenation exercise

### DIFF
--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -379,7 +379,7 @@ this query:
 > What does this actually produce, and why?
 {: .challenge}
 
-> ## Ordering When Concatenating
+> ## Using the group_concat function
 >
 > The function `group_concat(field, separator)`
 > concatenates all the values in a field
@@ -393,5 +393,11 @@ this query:
 > ~~~
 > {: .sql}
 >
-> Can you find a way to order the list by surname?
+> Can you find a way to list all the scientists separated by a : character?
+> > ~~~
+> > SELECT group_concat(personal || ' ' || family, ':') FROM Person;
+> > ~~~
+> > {: .sql}
+> {: .solution}
 {: .challenge}
+

--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -393,11 +393,20 @@ this query:
 > ~~~
 > {: .sql}
 >
-> Can you find a way to list all the scientists separated by a : character?
+> Can you find a way to list all the scientists family names separated by a comma?
+> Can you find a way to list all the scientists personal and family names separated by a comma?
+> > List all the family names separated by a comma:
 > > ~~~
-> > SELECT group_concat(personal || ' ' || family, ':') FROM Person;
+> > SELECT group_concat(family, ',') FROM Person;
 > > ~~~
 > > {: .sql}
+> >
+> > List all the full names separated by a comma:
+> > ~~~
+> > SELECT group_concat(personal || ' ' || family, ',') FROM Person;
+> > ~~~
+> > {: .sql}
+
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Removes the requirement to order the results in final aggregation exercise on concatenating. There was no solution for this exercise and solving it required using sub queries which haven't been discussed until now. 

I've simplified it to no need the results to be ordered, but instead to require a colon character as a separator. This way there's still a reason to use group_concat. 

This has been previously discussed in bugs #158, #255 and #288. A previous solution was proposed and then retracted in pull request #210.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
