### PR TITLE
Fix the South Pole filtering question

### DIFF
--- a/_episodes/03-filter.md
+++ b/_episodes/03-filter.md
@@ -240,7 +240,7 @@ not to the entire rows as they are being processed.
 
 > ## Fix This Query
 >
-> Suppose we want to select all sites that lie more than 48 degrees from the poles.
+> Suppose we want to select all sites that lie within 48 degrees of the equator.
 > Our first query is:
 >
 > ~~~


### PR DESCRIPTION
Hi all,

(I'm submitting this as part of my check procedure)

We noticed this problem during a recent workshop. The question is worded incorrectly because it is assuming the poles are at 0° when in fact they are at 90°. 

You could actually resolve this question in a number of ways depending on what you want to ask. The change I am submitting does the least amount of altering to the SQL and the ensuing results compared to other possible solutions and still maintains the spirit of the question, i.e. it filters some of them and leaves others by changing from an `OR` to an `AND`.
