### PR TITLE
Rename database manager to database engine

### DIFF
--- a/_episodes/01-select.md
+++ b/_episodes/01-select.md
@@ -177,7 +177,7 @@ we'll return to these missing values [later]({{ site.github.url }}/05-null/).
 > For a list of useful system commands, enter `.help`.
 >
 > All SQLite-specific commands are prefixed with a `.` to distinguish them from SQL commands.
-> 
+>
 > Type `.tables` to list the tables in the database.
 >
 > ~~~
@@ -203,11 +203,11 @@ we'll return to these missing values [later]({{ site.github.url }}/05-null/).
 > ~~~
 > {: .output}
 >
-> The output is formatted as <**columnName** *dataType*>.  Thus we can see from the first line that the table **Person** has three columns: 
+> The output is formatted as <**columnName** *dataType*>.  Thus we can see from the first line that the table **Person** has three columns:
 > * **id** with type _text_
 > * **personal** with type _text_
 > * **family** with type _text_
-> 
+>
 > Note: The available data types vary based on the database manager - you can search online for what data types are supported.
 >
 > You can change some SQLite settings to make the output easier to read.
@@ -346,7 +346,7 @@ SELECT * FROM Person;
 |danforth|Frank    |Danforth|
 
 > ## Understanding CREATE statements
-> 
+>
 > Use the `.schema` to identify column that contains integers.
 >
 > > ## Solution
@@ -362,7 +362,7 @@ SELECT * FROM Person;
 > > CREATE TABLE Visited (id integer, site text, dated text);
 > > ~~~
 > > {: .output}
-> > From the output, we see that the **taken** column in the **Survey** table (3rd line) is composed of integers. 
+> > From the output, we see that the **taken** column in the **Survey** table (3rd line) is composed of integers.
 > {: .solution}
 {: .challenge}
 
@@ -371,7 +371,7 @@ SELECT * FROM Person;
 > Write a query that selects only the `name` column from the `Site` table.
 >
 > > ## Solution
-> > 
+> >
 > > ~~~
 > > SELECT name FROM Site;
 > > ~~~

--- a/_episodes/01-select.md
+++ b/_episodes/01-select.md
@@ -6,11 +6,11 @@ questions:
 - "How can I get data from a database?"
 objectives:
 - "Explain the difference between a table, a record, and a field."
-- "Explain the difference between a database and a database manager."
+- "Explain the difference between a database and a database engine."
 - "Write a query to select all values for specific fields from a single table."
 keypoints:
 - "A relational database stores information in tables, each of which has a fixed set of columns and a variable number of records."
-- "A database manager is a program that manipulates information stored in a database."
+- "A database engine is a program that manipulates information stored in a database."
 - "We write queries in a specialized language called SQL to extract information from databases."
 - "Use SELECT... FROM... to get values from a database table."
 - "SQL is case-insensitive (but data is case-sensitive)."
@@ -26,9 +26,9 @@ we put formulas into cells to calculate new values based on old ones.
 When we are using a database,
 we send commands
 (usually called [queries]({{ site.github.url }}/reference.html#query))
-to a [database manager]({{ site.github.url }}/reference.html#database-manager):
+to a [database engine]({{ site.github.url }}/reference.html#database-manager):
 a program that manipulates the database for us.
-The database manager does whatever lookups and calculations the query specifies,
+The database engine does whatever lookups and calculations the query specifies,
 returning the results in a tabular form
 that we can then use as a starting point for further queries.
 
@@ -38,13 +38,13 @@ SQL provides hundreds of different ways to analyze and recombine data.
 We will only look at a handful of queries,
 but that handful accounts for most of what scientists do.
 
-> ## Changing Database Managers
+> ## Changing Database Engines
 >
-> Many database managers --- Oracle,
+> Many database engines --- Oracle,
 > IBM DB2, PostgreSQL, MySQL, Microsoft Access, and SQLite ---  understand
 > SQL but each stores data in a different way,
 > so a database created with one cannot be used directly by another.
-> However, every database manager
+> However, every database engine
 > can import and export data in a variety of formats like .csv, SQL,
 > so it *is* possible to move information from one to another.
 {: .callout}
@@ -208,7 +208,7 @@ we'll return to these missing values [later]({{ site.github.url }}/05-null/).
 > * **personal** with type _text_
 > * **family** with type _text_
 >
-> Note: The available data types vary based on the database manager - you can search online for what data types are supported.
+> Note: The available data types vary based on the database engine - you can search online for what data types are supported.
 >
 > You can change some SQLite settings to make the output easier to read.
 > First,
@@ -245,7 +245,7 @@ SELECT family, personal FROM Person;
 |Danforth|Frank    |
 
 The semicolon at the end of the query
-tells the database manager that the query is complete and ready to run.
+tells the database engine that the query is complete and ready to run.
 We have written our commands in upper case and the names for the table and columns
 in lower case,
 but we don't have to:

--- a/_episodes/02-sort-dup.md
+++ b/_episodes/02-sort-dup.md
@@ -229,7 +229,7 @@ SELECT DISTINCT quant, person FROM Survey ORDER BY quant ASC;
 > Write a query that selects distinct dates from the `Visited` table.
 >
 > > ## Solution
-> > 
+> >
 > > ~~~
 > > SELECT DISTINCT dated FROM Visited;
 > > ~~~
@@ -254,7 +254,7 @@ SELECT DISTINCT quant, person FROM Survey ORDER BY quant ASC;
 > ordered by family name.
 >
 > > ## Solution
-> > 
+> >
 > > ~~~
 > > SELECT personal, family FROM Person ORDER BY family ASC;
 > > ~~~

--- a/_episodes/03-filter.md
+++ b/_episodes/03-filter.md
@@ -253,7 +253,7 @@ not to the entire rows as they are being processed.
 >
 > > ## Solution
 > >
-> > Because we used `OR`, a site on the South Pole for example will still meet 
+> > Because we used `OR`, a site on the South Pole for example will still meet
 > > the second criteria and thus be included. Instead, we want to restrict this
 > > to sites that meet _both_ criteria:
 > >

--- a/_episodes/03-filter.md
+++ b/_episodes/03-filter.md
@@ -33,7 +33,7 @@ SELECT * FROM Visited WHERE site = 'DR-1';
 |622  |DR-1|1927-02-10|
 |844  |DR-1|1932-03-22|
 
-The database manager executes this query in two stages.
+The database engine executes this query in two stages.
 First,
 it checks at each row in the `Visited` table
 to see which ones satisfy the `WHERE`.
@@ -73,7 +73,7 @@ SELECT * FROM Visited WHERE site = 'DR-1' AND dated < '1930-01-01';
 
 > ## Date Types
 >
-> Most database managers have a special data type for dates.
+> Most database engines have a special data type for dates.
 > In fact, many have two:
 > one for dates,
 > such as "May 31, 1971",

--- a/_episodes/04-calc.md
+++ b/_episodes/04-calc.md
@@ -98,7 +98,7 @@ SELECT personal || ' ' || family FROM Person;
 > Write a query that returns all of her salinity measurements
 > from the `Survey` table
 > with the values divided by 100.
-> 
+>
 > > ## Solution
 > >
 > > ~~~
@@ -152,7 +152,7 @@ SELECT personal || ' ' || family FROM Person;
 > |752  |0.416  |
 > |837  |0.21   |
 > |837  |0.225  |
-> 
+>
 > > ## Solution
 > >
 > > ~~~

--- a/_episodes/04-calc.md
+++ b/_episodes/04-calc.md
@@ -38,7 +38,7 @@ the expression `1.05 * reading` is evaluated for each row.
 Expressions can use any of the fields,
 all of usual arithmetic operators,
 and a variety of common functions.
-(Exactly which ones depends on which database manager is being used.)
+(Exactly which ones depends on which database engine is being used.)
 For example,
 we can convert temperature readings from Fahrenheit to Celsius
 and round to two decimal places:

--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -130,7 +130,7 @@ SELECT person, count(*) FROM Survey WHERE quant = 'sal' AND reading <= 1.0;
 Why does Lake's name appear rather than Roerich's or Dyer's?
 The answer is that when it has to aggregate a field,
 but isn't told how to,
-the database manager chooses an actual value from the input set.
+the database engine chooses an actual value from the input set.
 It might use the first one processed,
 the last one,
 or something else entirely.
@@ -201,7 +201,7 @@ WHERE quant = 'rad';
 |------|--------------|----------------------|
 |roe   |8             |6.56                  |
 
-because the database manager selects a single arbitrary scientist's name
+because the database engine selects a single arbitrary scientist's name
 rather than aggregating separately for each scientist.
 Since there are only five scientists,
 we could write five queries of the form:
@@ -223,7 +223,7 @@ and if we ever had a data set with fifty or five hundred scientists,
 the chances of us getting all of those queries right is small.
 
 What we need to do is
-tell the database manager to aggregate the hours for each scientist separately
+tell the database engine to aggregate the hours for each scientist separately
 using a `GROUP BY` clause:
 
 ~~~
@@ -245,7 +245,7 @@ roe   |1             |11.25                 |
 groups all the records with the same value for the specified field together
 so that aggregation can process each batch separately.
 Since all the records in each batch have the same value for `person`,
-it no longer matters that the database manager
+it no longer matters that the database engine
 is picking an arbitrary one to display
 alongside the aggregated `reading` values.
 

--- a/_episodes/07-join.md
+++ b/_episodes/07-join.md
@@ -110,7 +110,7 @@ and for all the queries in this lesson you can use them interchangeably.
 There are differences in how they affect [outer joins][outer],
 but that's beyond the scope of this lesson.
 Once we add this to our query,
-the database manager throws away records
+the database engine throws away records
 that combined information about two different sites,
 leaving us with just the ones we want.
 

--- a/_episodes/07-join.md
+++ b/_episodes/07-join.md
@@ -234,13 +234,13 @@ SELECT rowid, * FROM Person;
 >
 > Write a query that lists all radiation readings from the DR-1 site.
  > > ## Solution
- > > 
+ > >
  > > ~~~
- > > SELECT Survey.reading 
- > > FROM Site JOIN Visited JOIN Survey 
+ > > SELECT Survey.reading
+ > > FROM Site JOIN Visited JOIN Survey
  > > ON Site.name = Visited.site
  > > AND Visited.id = Survey.taken
- > > WHERE Site.name = 'DR-1' 
+ > > WHERE Site.name = 'DR-1'
  > > AND Survey.quant = 'rad';
  > > ~~~
  > > {: .sql}
@@ -257,7 +257,7 @@ SELECT rowid, * FROM Person;
 >
 > Write a query that lists all sites visited by people named "Frank".
  > > ## Solution
- > > 
+ > >
  > > ~~~
  > > SELECT DISTINCT Site.name
  > > FROM Site JOIN Visited JOIN Survey JOIN Person
@@ -292,7 +292,7 @@ SELECT rowid, * FROM Person;
 > and the type of measurement taken and its reading. Please avoid all null values.
 > Tip: you should get 15 records with 8 fields.
  > > ## Solution
- > > 
+ > >
  > > ~~~
  > > SELECT Site.name, Site.lat, Site.long, Person.personal, Person.family, Survey.quant, Survey.reading, Visited.dated
  > > FROM Site JOIN Visited JOIN Survey JOIN Person

--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -52,7 +52,7 @@ but it's better not to have to rely on it.
 Different database systems support different data types for table columns,
 but most provide the following:
 
-|data type|  use                                       | 
+|data type|  use                                       |
 |---------|  ----------------------------------------- |
 |INTEGER  |  a signed integer                          |
 |REAL     |  a floating point number                   |

--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -89,7 +89,7 @@ CREATE TABLE Survey(
 Once again,
 exactly what constraints are available
 and what they're called
-depends on which database manager we are using.
+depends on which database engine we are using.
 
 Once tables have been created,
 we can add, change, and remove records using our other set of commands,
@@ -155,7 +155,7 @@ we need to ensure that all references between tables can always be resolved corr
 One way to do this is to delete all the records
 that use `'lake'` as a foreign key
 before deleting the record that uses it as a primary key.
-If our database manager supports it,
+If our database engine supports it,
 we can automate this
 using [cascading delete]({{ site.github.url }}/reference.html#cascading-delete).
 However,

--- a/_episodes/10-prog.md
+++ b/_episodes/10-prog.md
@@ -10,7 +10,7 @@ objectives:
 - "Explain why most database applications are written in a general-purpose language rather than in SQL."
 keypoints:
 - "General-purpose languages have libraries for accessing databases."
-- "To connect to a database, a program must use a library specific to that database manager."
+- "To connect to a database, a program must use a library specific to that database engine."
 - "These libraries use a connection-and-cursor model."
 - "Programs can read query results in batches or all at once."
 - "Queries should be written using parameter substitution, not string formatting."

--- a/_episodes/11-prog-R.md
+++ b/_episodes/11-prog-R.md
@@ -94,7 +94,7 @@ print(paste("full name for dyer:", getName('dyer')))
 dbDisconnect(connection)
 ~~~
 {: .r}
-~~~ 
+~~~
 full name for dyer: William Dyer
 ~~~
 {: .output}
@@ -104,7 +104,7 @@ to construct a query containing the user ID we have been given.
 This seems simple enough,
 but what happens if someone gives us this string as input?
 
-~~~ 
+~~~
 dyer'; DROP TABLE Survey; SELECT '
 ~~~
 {: .sql}
@@ -114,7 +114,7 @@ but it is very carefully chosen garbage.
 If we insert this string into our query,
 the result is:
 
-~~~ 
+~~~
 SELECT personal || ' ' || family FROM Person WHERE id='dyer'; DROP TABLE Survey; SELECT '';
 ~~~
 {: .sql}
@@ -127,10 +127,10 @@ and it has been used to attack thousands of programs over the years.
 In particular,
 many web sites that take data from users insert values directly into queries
 without checking them carefully first.
-A very [relevant XKCD](https://xkcd.com/327/) that explains the 
+A very [relevant XKCD](https://xkcd.com/327/) that explains the
 dangers of using raw input in queries a little more succinctly:
 
-![relevant XKCD](https://imgs.xkcd.com/comics/exploits_of_a_mom.png) 
+![relevant XKCD](https://imgs.xkcd.com/comics/exploits_of_a_mom.png)
 
 Since an unscrupulous parent might try to smuggle commands into our queries in many different ways,
 the safest way to deal with this threat is
@@ -140,7 +140,7 @@ We can do this by using a [prepared statement]({{ site.github.url }}/reference.h
 instead of formatting our statements as strings.
 Here's what our example program looks like if we do this:
 
-~~~ 
+~~~
 library(RSQLite)
 connection <- dbConnect(SQLite(), "survey.db")
 
@@ -154,7 +154,7 @@ print(paste("full name for dyer:", getName('dyer')))
 dbDisconnect(connection)
 ~~~
 {: .r}
-~~~ 
+~~~
 full name for dyer: William Dyer
 ~~~
 {: .output}
@@ -170,7 +170,7 @@ and translates any special characters in the values
 into their escaped equivalents
 so that they are safe to use.
 
-> ## Filling a Table vs. Printing Values 
+> ## Filling a Table vs. Printing Values
 >
 > Write an R program that creates a new database in a file called
 > `original.db` containing a single table called `Pressure`, with a
@@ -191,13 +191,13 @@ so that they are safe to use.
 
 ## Database helper functions in R
 
-R's database interface packages (like `RSQLite`) all share 
-a common set of helper functions useful for exploring databases and 
+R's database interface packages (like `RSQLite`) all share
+a common set of helper functions useful for exploring databases and
 reading/writing entire tables at once.
 
 To view all tables in a database, we can use `dbListTables()`:
 
-~~~ 
+~~~
 connection <- dbConnect(SQLite(), "survey.db")
 dbListTables(connection)
 ~~~
@@ -237,9 +237,9 @@ dbReadTable(connection, "Person")
 {: .output}
 
 
-Finally to write an entire table to a database, you can use `dbWriteTable()`. 
-Note that we will always want to use the `row.names = FALSE` argument or R 
-will write the row names as a separate column. 
+Finally to write an entire table to a database, you can use `dbWriteTable()`.
+Note that we will always want to use the `row.names = FALSE` argument or R
+will write the row names as a separate column.
 In this example we will write R's built-in `iris` dataset as a table in `survey.db`.
 
 ~~~
@@ -264,4 +264,3 @@ And as always, remember to close the database connection when done!
 dbDisconnect(connection)
 ~~~
 {: .r}
-

--- a/_episodes/11-prog-R.md
+++ b/_episodes/11-prog-R.md
@@ -10,7 +10,7 @@ objectives:
 - "Explain why most database applications are written in a general-purpose language rather than in SQL."
 keypoints:
 - "Data analysis languages have libraries for accessing databases."
-- "To connect to a database, a program must use a library specific to that database manager."
+- "To connect to a database, a program must use a library specific to that database engine."
 - "R's libraries can be used to directly query or read from a database."
 - "Programs can read query results in batches or all at once."
 - "Queries should be written using parameter substitution, not string formatting."

--- a/reference.md
+++ b/reference.md
@@ -35,7 +35,7 @@ cross product
 cursor
 :   A pointer into a database that keeps track of outstanding operations.
 
-database manager
+database engine
 :   A program that manages a database, such as SQLite.
 
 fields


### PR DESCRIPTION
Replace all mentions of "database manager" with "database engine". "Database management system" would also be an acceptable substitute for "database manager". 


Please see the issue I created, #297 for more context. 
