### PR TITLE
use link Jekyll command instead of site.github.url

### DIFF
--- a/_episodes/01-select.md
+++ b/_episodes/01-select.md
@@ -15,24 +15,24 @@ keypoints:
 - "Use SELECT... FROM... to get values from a database table."
 - "SQL is case-insensitive (but data is case-sensitive)."
 ---
-A [relational database]({{ site.github.url }}/reference.html#relational-database)
+A [relational database]({% link reference.md %}#relational-database)
 is a way to store and manipulate information.
-Databases are arranged as [tables]({{ site.github.url }}/reference.html#table).
-Each table has columns (also known as [fields]({{ site.github.url }}/reference.html#fields)) that describe the data,
-and rows (also known as [records]({{ site.github.url }}/reference.html#record)) which contain the data.
+Databases are arranged as [tables]({% link reference.md %}#table).
+Each table has columns (also known as [fields]({% link reference.md %}#fields)) that describe the data,
+and rows (also known as [records]({% link reference.md %}#record)) which contain the data.
 
 When we are using a spreadsheet,
 we put formulas into cells to calculate new values based on old ones.
 When we are using a database,
 we send commands
-(usually called [queries]({{ site.github.url }}/reference.html#query))
-to a [database manager]({{ site.github.url }}/reference.html#database-manager):
+(usually called [queries]({% link reference.md %}#query))
+to a [database manager]({% link reference.md %}#database-manager):
 a program that manipulates the database for us.
 The database manager does whatever lookups and calculations the query specifies,
 returning the results in a tabular form
 that we can then use as a starting point for further queries.
 
-Queries are written in a language called [SQL]({{ site.github.url }}/reference.html#sql),
+Queries are written in a language called [SQL]({% link reference.md %}#sql),
 which stands for "Structured Query Language".
 SQL provides hundreds of different ways to analyze and recombine data.
 We will only look at a handful of queries,
@@ -250,7 +250,7 @@ We have written our commands in upper case and the names for the table and colum
 in lower case,
 but we don't have to:
 as the example below shows,
-SQL is [case insensitive]({{ site.github.url }}/reference.html#case-insensitive).
+SQL is [case insensitive]({% link reference.md %}#case-insensitive).
 
 ~~~
 SeLeCt FaMiLy, PeRsOnAl FrOm PeRsOn;

--- a/_episodes/03-filter.md
+++ b/_episodes/03-filter.md
@@ -14,7 +14,7 @@ keypoints:
 - "Write queries incrementally."
 ---
 One of the most powerful features of a database is
-the ability to [filter]({{ site.github.url }}/reference.html#filter) data,
+the ability to [filter]({% link reference.md %}#filter) data,
 i.e.,
 to select only those records that match certain criteria.
 For example,
@@ -176,7 +176,7 @@ SELECT * FROM Survey WHERE quant = 'sal' AND (person = 'lake' OR person = 'roe')
 We can also filter by partial matches.  For example, if we want to
 know something just about the site names beginning with "DR" we can
 use the `LIKE` keyword.  The percent symbol acts as a
-[wildcard]({{ site.github.url }}/reference.html#wildcard), matching any characters in that
+[wildcard]({% link reference.md %}#wildcard), matching any characters in that
 place.  It can be used at the beginning, middle, or end of the string:
 
 ~~~

--- a/_episodes/05-null.md
+++ b/_episodes/05-null.md
@@ -240,7 +240,7 @@ detail in [the next section]({{ site.github.url }}/06-agg/).
 > ## Pros and Cons of Sentinels
 >
 > Some database designers prefer to use
-> a [sentinel value]({{ site.github.url }}/reference.html#sentinel-value)
+> a [sentinel value]({% link reference.md %}#sentinel-value)
 > to mark missing data rather than `null`.
 > For example,
 > they will use the date "0000-00-00" to mark a missing date,

--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -36,7 +36,7 @@ SELECT dated FROM Visited;
 |1932-03-22|
 
 but to combine them,
-we must use an [aggregation function]({{ site.github.url }}/reference.html#aggregation-function)
+we must use an [aggregation function]({% link reference.md %}#aggregation-function)
 such as `min` or `max`.
 Each of these functions takes a set of records as input,
 and produces a single record as output:

--- a/_episodes/07-join.md
+++ b/_episodes/07-join.md
@@ -70,7 +70,7 @@ SELECT * FROM Site JOIN Visited;
 |MSK-4|-48.87|-123.4 |844  |DR-1  |1932-03-22|
 
 `JOIN` creates
-the [cross product]({{ site.github.url }}/reference.html#cross-product)
+the [cross product]({% link reference.md %}#cross-product)
 of two tables,
 i.e.,
 it joins each record of one table with each record of the other table
@@ -185,8 +185,8 @@ AND    Visited.dated IS NOT NULL;
 We can tell which records from `Site`, `Visited`, and `Survey`
 correspond with each other
 because those tables contain
-[primary keys]({{ site.github.url }}/reference.html#primary-key)
-and [foreign keys]({{ site.github.url }}/reference.html#foreign-key).
+[primary keys]({% link reference.md %}#primary-key)
+and [foreign keys]({% link reference.md %}#foreign-key).
 A primary key is a value,
 or combination of values,
 that uniquely identifies each record in a table.

--- a/_episodes/08-hygiene.md
+++ b/_episodes/08-hygiene.md
@@ -21,7 +21,7 @@ keypoints:
 
 Now that we have seen how joins work, we can see why the relational
 model is so useful and how best to use it.  The first rule is that
-every value should be [atomic]({{ site.github.url }}/reference.html#atomic), i.e., not
+every value should be [atomic]({% link reference.md %}#atomic), i.e., not
 contain parts that we might want to work with separately.  We store
 personal and family names in separate columns instead of putting the
 entire name in one column so that we don't have to use substring

--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -150,14 +150,14 @@ but that's never supposed to happen:
 and all our queries assume there will be a row in the latter
 matching every value in the former.
 
-This problem is called [referential integrity]({{ site.github.url }}/reference.html#referential-integrity):
+This problem is called [referential integrity]({% link reference.md %}#referential-integrity):
 we need to ensure that all references between tables can always be resolved correctly.
 One way to do this is to delete all the records
 that use `'lake'` as a foreign key
 before deleting the record that uses it as a primary key.
 If our database manager supports it,
 we can automate this
-using [cascading delete]({{ site.github.url }}/reference.html#cascading-delete).
+using [cascading delete]({% link reference.md %}#cascading-delete).
 However,
 this technique is outside the scope of this chapter.
 
@@ -191,7 +191,7 @@ this technique is outside the scope of this chapter.
 
 > ## Generating Insert Statements
 >
-> One of our colleagues has sent us a [CSV]({{ site.github.url }}/reference.html#comma-separated-values-csv) file containing
+> One of our colleagues has sent us a [CSV]({% link reference.md %}#comma-separated-values-csv) file containing
 > temperature readings by Robert Olmstead, which is formatted like
 > this:
 >

--- a/_episodes/10-prog.md
+++ b/_episodes/10-prog.md
@@ -57,7 +57,7 @@ Line 2 establishes a connection to the database.
 Since we're using SQLite,
 all we need to specify is the name of the database file.
 Other systems may require us to provide a username and password as well.
-Line 3 then uses this connection to create a [cursor]({{ site.github.url }}/reference.html#cursor).
+Line 3 then uses this connection to create a [cursor]({% link reference.md %}#cursor).
 Just like the cursor in an editor,
 its role is to keep track of where we are in the database.
 
@@ -137,7 +137,7 @@ SELECT personal || ' ' || family FROM Person WHERE id='dyer'; DROP TABLE Survey;
 If we execute this,
 it will erase one of the tables in our database.
 
-This is called an [SQL injection attack]({{ site.github.url }}/reference.html#sql-injection-attack),
+This is called an [SQL injection attack]({% link reference.md %}#sql-injection-attack),
 and it has been used to attack thousands of programs over the years.
 In particular,
 many web sites that take data from users insert values directly into queries
@@ -147,7 +147,7 @@ Since a villain might try to smuggle commands into our queries in many different
 the safest way to deal with this threat is
 to replace characters like quotes with their escaped equivalents,
 so that we can safely put whatever the user gives us inside a string.
-We can do this by using a [prepared statement]({{ site.github.url }}/reference.html#prepared-statement)
+We can do this by using a [prepared statement]({% link reference.md %}#prepared-statement)
 instead of formatting our statements as strings.
 Here's what our example program looks like if we do this:
 

--- a/_episodes/11-prog-R.md
+++ b/_episodes/11-prog-R.md
@@ -122,7 +122,7 @@ SELECT personal || ' ' || family FROM Person WHERE id='dyer'; DROP TABLE Survey;
 If we execute this,
 it will erase one of the tables in our database.
 
-This is called an [SQL injection attack]({{ site.github.url }}/reference.html#sql-injection-attack),
+This is called an [SQL injection attack]({% link reference.md %}#sql-injection-attack),
 and it has been used to attack thousands of programs over the years.
 In particular,
 many web sites that take data from users insert values directly into queries
@@ -136,7 +136,7 @@ Since an unscrupulous parent might try to smuggle commands into our queries in m
 the safest way to deal with this threat is
 to replace characters like quotes with their escaped equivalents,
 so that we can safely put whatever the user gives us inside a string.
-We can do this by using a [prepared statement]({{ site.github.url }}/reference.html#prepared-statement)
+We can do this by using a [prepared statement]({% link reference.md %}#prepared-statement)
 instead of formatting our statements as strings.
 Here's what our example program looks like if we do this:
 


### PR DESCRIPTION
## Current situation

Locally, using `make serve` runs the command `jekyll serve`. As such, the `github-metadata` plugin is not enabled and the variable `site.github.url` is undefined (`null`), so an url such as `{{ site.github.url }}/reference.html#relational-database` will become `http://localhost:4000/reference.html#relational-database` (which works).

On GitHub pages, bundler is being used and the `github-metadata` jekyll plugin is enabled. In this case, `{{ site.github.url }}` is set to `https://swcarpentry.github.io/sql-novice-survey` and the links work as expected.

## Proposed change

With the [transition to using bundler](https://github.com/carpentries/maintainer-RFCs/issues/1), which was tested in #299, using `site.github.url` locally leads to an error as additional set up is needed to use the actual GitHub metadata locally.

In preparation for the transition to bundler I propose using the `{% link ... %}` Jekyll command which builds the relative path for the rendered file.
