### PR TITLE
Ep 6: Remove exercise "Ordering When Concatenating"

### DIFF
--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -378,20 +378,3 @@ this query:
 >
 > What does this actually produce, and why?
 {: .challenge}
-
-> ## Ordering When Concatenating
->
-> The function `group_concat(field, separator)`
-> concatenates all the values in a field
-> using the specified separator character
-> (or ',' if the separator isn't specified).
-> Use this to produce a one-line list of scientists' names,
-> such as:
->
-> ~~~
-> William Dyer, Frank Pabodie, Anderson Lake, Valentina Roerich, Frank Danforth
-> ~~~
-> {: .sql}
->
-> Can you find a way to order the list by surname?
-{: .challenge}


### PR DESCRIPTION
(I'm splitting #267 into separate PRs. This is part 3, a partial extract from fcb588e)

This PR removes the exercise "Ordering When Concatenating" since it doesn't seem like there is a solution that doesn't depend on subqueries, a concept not yet been introduced. See #288.

<s>Note that there is also another PR (#289) that instead adjusts the exercise so that it *can* be solved. While this is an improvement, we still think this exercise is a bit too hard, and that the introduction of `group_concat` is unneccessary in an introductory course. </s>

On second thought, we're closing this in favour of #289