### PR TITLE
Ep9: Fix INSERT datatypes + slight rephrasing

### DIFF
--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -107,7 +107,7 @@ INSERT INTO Site (name, lat, long) VALUES ('MSK-4', -48.87, -123.40);
 We can also insert values into one table directly from another:
 
 ~~~
-CREATE TABLE JustLatLong(lat text, long text);
+CREATE TABLE JustLatLong(lat real, long real);
 INSERT INTO JustLatLong SELECT lat, long FROM Site;
 ~~~
 {: .sql}

--- a/_episodes/09-create.md
+++ b/_episodes/09-create.md
@@ -95,7 +95,7 @@ Once tables have been created,
 we can add, change, and remove records using our other set of commands,
 `INSERT`, `UPDATE`, and `DELETE`.
 
-The simplest form of `INSERT` statement lists values in order:
+Here is an example of inserting rows into the `Site` table:
 
 ~~~
 INSERT INTO Site (name, lat, long) VALUES ('DR-1', -49.85, -128.57);
@@ -118,7 +118,7 @@ what we want to change the values to for any or all of the fields,
 and under what conditions we should update the values.
 
 For example, if we made a mistake when entering the lat and long values
-of the last `INSERT` statement above:
+of the last `INSERT` statement above, we can correct it with an update:
 
 ~~~
 UPDATE Site SET lat = -47.87, long = -122.40 WHERE name = 'MSK-4';


### PR DESCRIPTION
I'm splitting #267 into separate PRs. This is part 5 (the last one), partial extract from ce0ee7799874840c2f066735192e1b182b17deb1

This PR fixes the datatypes in one of the CREATE statements and does a slight rephrasing of these two senteneces:

- "The simplest form of `INSERT` statement lists values in order": I think this sentence was a reminisce from before the column names were added to the query.
- "For example, if we made a mistake when entering the lat and long values of the last `INSERT` statement above:" ended rather abruptly.
