### PR TITLE
Explain NULLs when teaching count

### DIFF
--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -97,10 +97,11 @@ SELECT sum(reading) FROM Survey WHERE quant = 'sal';
 We used `count(reading)` here,
 but could have used `count(*)`,
 since the function doesn't care about the values themselves,
-just how many values there are.
+just how many rows there are.
 Even a column other than `reading` could be used,
 but note that any `NULL` value will not be counted
-(try counting the `person` column instead).
+(to see, try `count`ing the `person` column, which contains a
+row with a `NULL`).
 This perhaps non-obvious behavior
 of aggregation functions is covered later
 in this episode.

--- a/_episodes/06-agg.md
+++ b/_episodes/06-agg.md
@@ -95,11 +95,15 @@ SELECT sum(reading) FROM Survey WHERE quant = 'sal';
 |64.83       |
 
 We used `count(reading)` here,
-but we could just as easily have counted `quant`
-or any other field in the table,
-or even used `count(*)`,
+but could have used `count(*)`,
 since the function doesn't care about the values themselves,
 just how many values there are.
+Even a column other than `reading` could be used,
+but note that any `NULL` value will not be counted
+(try counting the `person` column instead).
+This perhaps non-obvious behavior
+of aggregation functions is covered later
+in this episode.
 
 SQL lets us do several aggregations at once.
 We can,


### PR DESCRIPTION
The removes a small oversight in the current explanation, that columns with NULL values are not counted.  It also teases the fuller explanation of NULL and aggregation that comes later.

Closes #305 
