### PR TITLE
Fix rendering bug with markdown table headers

### DIFF
--- a/_episodes/04-calc.md
+++ b/_episodes/04-calc.md
@@ -82,7 +82,7 @@ SELECT personal || ' ' || family FROM Person;
 ~~~
 {: .sql}
 
-|personal || ' ' || family|
+|personal \|\| ' ' \|\| family|
 |-------------------------|
 |William Dyer             |
 |Frank Pabodie            |


### PR DESCRIPTION
The results table for the example query `SELECT personal || ' ' || family FROM Person;` displays incorrectly, because the `||` are treated by Markdown as table column separators:

<img width="982" alt="Calculating_New_Values_–_Databases_and_SQL" src="https://user-images.githubusercontent.com/9599/94616448-d85b2c80-025d-11eb-8188-3e11a22d3180.png">

Escaping those `|` symbols with `\|` should fix that:

<img width="217" alt="Comparing_swcarpentry_gh-pages___simonw_patch-1_·_swcarpentry_sql-novice-survey" src="https://user-images.githubusercontent.com/9599/94616655-ea3ccf80-025d-11eb-8ef7-6d9cfd4c46af.png">
