### PR TITLE
Update R SQL chapter for DBI best practice

### DIFF
--- a/_episodes/11-prog-R.md
+++ b/_episodes/11-prog-R.md
@@ -82,7 +82,7 @@ getName <- function(personID) {
 
 print(paste("full name for dyer:", getName('dyer')))
 
-dbDisconnect(connection)
+dbDisconnect(con)
 ~~~
 {: .r}
 ~~~ 
@@ -141,7 +141,7 @@ getName <- function(personID) {
 
 print(paste("full name for dyer:", getName('dyer')))
 
-dbDisconnect(connection)
+dbDisconnect(con)
 ~~~
 {: .r}
 ~~~ 


### PR DESCRIPTION
A couple of changes to bring this chapter in line with R {DBI} best practices:

* Updated text to reflect use of DBI package as uniform API for DB's from R.
* Connect statements now use `RSQLite::SQLite()` instead of attaching {RSQLite}
* Parameterized query now uses `DBI::dbGetQuery()` with `params` argument.
* removed explicit `return()` and `print()` calls.