### PR TITLE
Correct "quantitative" to "quantity"

### DIFF
--- a/_episodes/01-select.md
+++ b/_episodes/01-select.md
@@ -108,7 +108,7 @@ Before we get into using SQLite to select the data, let's take a look at the tab
   </div>
   <div class="col-md-6" markdown="1">
 
-**Survey**: the actual readings.  The field `quant` is short for quantitative and indicates what is being measured.  Values are `rad`, `sal`, and `temp` referring to 'radiation', 'salinity' and 'temperature', respectively.
+**Survey**: the actual readings.  The field `quant` is short for quantity and indicates what is being measured.  Values are `rad`, `sal`, and `temp` referring to 'radiation', 'salinity' and 'temperature', respectively.
 
 |taken|person|quant|reading|
 |-----|------|-----|-------|


### PR DESCRIPTION
"Radiation", "Salinity" and "temperature" are the names of *quantities*, so "quant" is surely short for "quantity" rather than "quantitative".

This is also what was assumed by remram44 and cwant in the discussion on https://github.com/swcarpentry/sql-novice-survey/issues/239.