### PR TITLE
Correct SQL query in lesson

### DIFF
--- a/_episodes/07-join.md
+++ b/_episodes/07-join.md
@@ -90,10 +90,7 @@ we're only interested in combinations that have the same site name,
 thus we need to use a filter:
 
 ~~~
-SELECT
-  Site.lat,
-  Site.long,
-  Visited.dated
+SELECT *
 FROM
   Site
   JOIN Visited ON Site.name = Visited.site;


### PR DESCRIPTION
This PR identifies what appears to be an error in Chapter 7 of the SQL Novice Lesson. 

As written, the two JOIN examples were identical. The first one should be selecting all columns `(SELECT *)`, so that the point of the second one (only selecting the columns you need) comes across.
