### PR TITLE
fix broken block quote

### DIFF
--- a/_episodes/01-select.md
+++ b/_episodes/01-select.md
@@ -221,10 +221,10 @@ we'll return to these missing values
 > ~~~
 > {: .sql}
 >
-Alternatively, you can get the settings automatically by creating a `.sqliterc` file.
-Add the commands above and reopen SQLite.
-For Windows, use `C:\Users\<yourusername>.sqliterc`.
-For Linux/MacOS, use `/Users/<yourusername>/.sqliterc`.
+> Alternatively, you can get the settings automatically by creating a `.sqliterc` file.
+> Add the commands above and reopen SQLite.
+> For Windows, use `C:\Users\<yourusername>.sqliterc`.
+> For Linux/MacOS, use `/Users/<yourusername>/.sqliterc`.
 >
 > To exit SQLite and return to the shell command line,
 > you can use either `.quit` or `.exit`.


### PR DESCRIPTION
There was a callout block in episode 1 that was broken and caused issues with the transition (see https://fishtree-attempt.github.io/sql-novice-survey/01-select.html#checking-if-data-is-available).

This PR will fix it and make it appear as a callout block instead of a block quote