### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub release][shields_release]][swc_sql_novice_survey_releases]
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-swc--sql-E01563.svg)](https://swcarpentry.slack.com/messages/C9X3YNVNY)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-swc--sql-E01563.svg)](https://carpentries.slack.com/messages/C9X3YNVNY)
 [![DOI][zenodo_badge_DOI]][all_releases_DOI]
 
 # sql-novice-survey


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.