### PR TITLE
Databases and SQL - Corrected the query to match the output displayed.

### DIFF
--- a/episodes/07-join.md
+++ b/episodes/07-join.md
@@ -90,9 +90,7 @@ thus we need to use a filter:
 
 ```sql
 SELECT
-  Site.lat,
-  Site.long,
-  Visited.dated
+  *
 FROM
   Site
   JOIN Visited ON Site.name = Visited.site;


### PR DESCRIPTION
The columns selected in the join query don't match the output displayed below it. it should have selected all columns. 

This Query, if not corrected, is misleading and is redundant with the next example in the same lesson.

The screenshot below shows the extra columns displayed, which don't align with the query.

![image](https://github.com/swcarpentry/sql-novice-survey/assets/16373755/2c00ee7a-668b-4050-9414-8d01bd67928a)

