### PR TITLE
Clarified software installation instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -4,7 +4,7 @@ title: Setup
 
 # Software
 
-For this course you will need the UNIX shell, plus [SQLite3](https://www.sqlite.org/) or
+For this course you will need the UNIX shell (described in the [UNIX Shell lesson](https://swcarpentry.github.io/shell-novice/#install-software)), plus [SQLite3](https://www.sqlite.org/) or
 [DB Browser for SQLite](https://sqlitebrowser.org/).
 
 If you are running **macOS** you should already have SQLite installed. You can run `sqlite3 --version`
@@ -15,10 +15,8 @@ If you are running **Linux**, you may already have SQLite3 installed, please use
 `which sqlite3` to see the path of the program, otherwise you should be able to get it
 from your package manager (on Debian/Ubuntu, you can use the command `apt install sqlite3`).
 
-If you are running **Windows**, run installers as administrator.
-Additionally, make sure you select the right installer version for your system.
-We recommend that you use [git for Windows](https://gitforwindows.org/).
-This is described in the [UNIX Shell lesson](https://swcarpentry.github.io/shell-novice/setup.html).
+If you are running **Windows**, download installers and run them as administrator.
+Make sure you select the right installer version for your system.
 If the installer asks to add the path to the environment variables, check yes, otherwise you have to manually add the path of the executable to the `PATH` environmental variables.
 This path informs the system where to find the executable program.
 


### PR DESCRIPTION
Clarification of software section, particularly for Windows.

- Added opening line link for UNIX shell installation, alongside the existing links for SQLite.
- Windows text was confusing, being unclear how "git for Windows" related to the SQLite installers. The link to the UNIX Shell session was also broken. Both of these are now replaced by the link in the opening line.

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
